### PR TITLE
Custom setting fixes and improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ This plugin adds the ability to create presets from your RuneLite plugin configu
 
 Download the Plugin Presets plugin from the RuneLite Plugin Hub and enable it.
 
-Click the green + sign to create a new empty _plugin preset_. Plugin Preset are text files that are stored in your presets folder at `~/.runelite/presets/` or alternatively in your RuneLite configurations in `~/.runelite/settings.properties` file and they store any configurations that you can edit from the RuneLite configuration sidepanel.
+Click the green + sign to create a new empty _plugin preset_. Plugin Presets are text files that are stored in your presets folder at `~/.runelite/presets/` or alternatively in your RuneLite configurations in `~/.runelite/settings.properties` file and they store any configurations that you can edit from the RuneLite configuration sidepanel.
 
-The orange switch indicates whether or not the presets saved configurations **match** your current configurations. Loading a preset will copy all of those setting in the preset file to your current runelite configurations as if you manually changed all of your plugin configurations to match the presets ones. If the switch is off, it means that some of your configurations don't match the presets configurations.
+The orange switch indicates whether the preset's saved configurations **match** your current configurations. Loading a preset will copy all of those setting in the preset file to your current RuneLite configurations as if you manually changed all of your plugin configurations to match the presets ones. If the switch is off, it means that some of your configurations don't match the presets configurations.
 
 The cog icon in the preset panel opens the preset editor. In the editor view you can view, add, update and remove plugin configurations from your plugin presets. The checkboxes visualize whether or not the preset has stored any configurations to a certain plugin. If the checkbox is checked, that preset has stored some configurations and loading it will enable those configurations for you.
 
@@ -20,15 +20,15 @@ When the presets and your configurations differ, the edit panel will display a *
 
 ![Update demo](readme_visuals/update_preset_demo.gif)
 
-The modification icon does not mean that you need to allways update that configuration since the reason to use this plugin is to have the ability to change between different configurations easily. For example you could have 2 presets that store different color configurations to the skybox plugin and when enabling one of the presets, naturally the other preset will display a modified icon since, from the other presets perspective, the configurations have changed since creation.  
+The modification icon does not mean that you need to always update that configuration since the reason to use this plugin is to have the ability to change between different configurations easily. For example, you could have 2 presets that store different color configurations to the skybox plugin and when enabling one of the presets, naturally the other preset will display a modified icon since, from the other preset's perspective, the configurations have changed since creation.  
 
-Presets can be bound to custom keybinds by clicking the _Not set_ text. After cliking, type a key combination and it should be show on the panel. Once you are happy with the keybind, click save or press enter. Now the preset gets loaded after you press the keybind in game. Note that other plugins also have keybinds and those may or may not override your preset keybind, so prefer not to use duplicate keybindings.
+Presets can be bound to custom keybinds by clicking the _Not set_ text. After clicking, type a key combination and it should be show on the panel. Once you are happy with the keybind, click save or press enter. Now the preset gets loaded after you press the keybind in game. Note that other plugins also have keybinds and those may or may not override your preset keybind, so prefer not to use duplicate keybindings.
 
-> Single keybind only enables one preset so if you want to enable multiple presets with one keybind, consider creating a single preset containing the configurations from the presets you wish to enable.
+> A single keybind only enables one preset, so if you want to enable multiple presets with one keybind, consider creating a single preset containing the configurations from the presets you wish to enable.
 
 ![Keybind demo](readme_visuals/keybind_demo.gif)
 
-Presets can be loaded based on RuneLite client focus or unfocus. You can set the desired focus activation by right-clicking the load preset icon. Client unfocus can hapen when alt tabbing to other window, opening some other RuneLite sidebar panel, opening some context menu or popup. You can temporarily pause the focus activation by clicking the play/pause button in the top right corner. One should **pause the focus activation** if making changes to preset configurations (editing configurations, keybinds or renaming presets) or editing other RuneLite plugin configurations.
+Presets can be loaded based on RuneLite client focus or unfocus. You can set the desired focus activation by right-clicking the load preset icon. Client unfocus can happen when alt tabbing to another window, opening some other RuneLite sidebar panel, opening some context menu or popup. You can temporarily pause the focus activation by clicking the play/pause button in the top right corner. One should **pause the focus activation** if making changes to preset configurations (editing configurations, keybinds or renaming presets) or editing other RuneLite plugin configurations.
 
 Focus activation can be e.g. used to turn some plugins off to lower RuneLites computing power, limit draw distance or maybe make the client smaller when not using it. It's recommended to use focus activation with care since loading big presets will cause lag from loading many configurations and mostly cause more problems than help.
 
@@ -36,23 +36,25 @@ Focus activation can be e.g. used to turn some plugins off to lower RuneLites co
 
 ---
 
-Your plugin presets can become fairly messy after a while or cause problems if changing a lot of configurations between preset creations. To avoid confusion and problems, name your presets well, keep your presets up to date. Prefer to have presets **only contain the configurations you wish to change**, this also increases performance and reduces the strain to keep your presets up to date.
+Your plugin presets can become fairly messy after a while or cause problems if changing a lot of configurations between preset creations. To avoid confusion and problems, name your presets well and keep your presets up to date. Prefer to have presets **only contain the configurations you wish to change**, this also increases performance and reduces the strain to keep your presets up to date. You might want to consider only toggling complex plugins on or off in your preset rather than have it modify all the plugin's settings.
 
 ### Sharing plugin presets
 
-Your presets are stored in the `~/.runelite/presets/` folder or alternative in the `settings.properties` configuration file. In the preset editor view you can toggle where the plugin is stored by clicking the file/cloud icon.
+Your presets are stored in the `~/.runelite/presets/` folder or alternatively in the `settings.properties` configuration file. In the preset editor view you can toggle where the plugin is stored by clicking the file/cloud icon.
 
-You can share these _.json_ files with others, they don't contain information about your account, Discord or Twitch. Alternatively you can click the copy icon in the preset panel to copy the presets data to your clipboard for easier sharing e.g. through Discord, Pastebin etc...
+You can share these _.json_ files with others, they don't contain information about your account, Discord or Twitch. Alternatively you can click the copy icon in the preset panel to copy the preset's data to your clipboard for easier sharing e.g. through Discord, Pastebin etc...
 
 To "install" new presets, paste the .json file to the preset folder and then press the "refresh presets" button. Alternatively you can right-click the green + sign to import presets from clipboard. You can easily access your preset folder by right-clicking the Plugin Preset icon in the RuneLite sidebar.
 
-Note that external presets might contain configurations different to yours, so when enabling presets from others, they might have changed e.g. keybinds that you might have set up differently. In the edit panel, you can view the plugins that the preset has some configurations. Alternatively you can view the raw [json](https://en.wikipedia.org/wiki/JSON) by copying it and pasting it to a [json viewer](http://jsonviewer.stack.hu/). **When sending presets to others, make sure to always double check for sensetive information!**
+Note that external presets might contain configurations different to yours, so when enabling presets from others, they might have changed e.g. keybinds that you might have set up differently. In the edit panel, you can view the plugins that the preset has some configurations. Alternatively you can view the raw [json](https://en.wikipedia.org/wiki/JSON) by copying it and pasting it to a [json viewer](http://jsonviewer.stack.hu/). **When sending presets to others, make sure to always double-check for sensitive information!**
 
 ### Custom settings
 
-Some plugins have settings that are not configurable from the configurations tab such as screen markers or object indicators. You can add those settings that are not included in presets by right clicking the config name and choosing _Add custom setting_.
+Some plugins have settings that are not configurable from the configurations tab, such as screen markers, object indicators, or ground markers. You can add those settings that are not included in presets by right-clicking the config name and choosing _Add custom setting_.
 
-Custom settings require the configs _configName_ and the custom settings _settingKey_. You can find those from your `settings.properties` file in `~/.runelite/` folder. **There is no guaranteed that custom settings work correctly for some plugins since mostly those settings are not meant to be changed on the fly. Use at your own risk.**
+Custom settings require the config's _configName_ and the custom settings _settingKey_. You can find those from your `settings.properties` file in `~/.runelite/` folder. **There is no guarantee that custom settings will work correctly, since most of these settings are not meant to be changed on the fly. Use this feature at your own risk.**
+
+Custom settings in your configs are marked with a (C). If you uncheck a custom setting, it will be removed from your preset.
 
 <details>
   <summary>Adding screen markers to presets</summary>

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.9.1'
+def runeLiteVersion = '1.9.3'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion
@@ -24,7 +24,7 @@ dependencies {
 }
 
 group = 'com.pluginpresets'
-version = '2.3.1'
+version = '2.3.2'
 sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {

--- a/src/main/java/com/pluginpresets/CurrentConfigurations.java
+++ b/src/main/java/com/pluginpresets/CurrentConfigurations.java
@@ -29,6 +29,9 @@ import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
 
+/**
+ * Helper class that retrieves the user's current set of configs periodically
+ */
 public class CurrentConfigurations
 {
 	@Getter

--- a/src/main/java/com/pluginpresets/CustomSetting.java
+++ b/src/main/java/com/pluginpresets/CustomSetting.java
@@ -27,6 +27,9 @@ package com.pluginpresets;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
+/**
+ * One custom plugin setting within a config within a preset.
+ */
 @Data
 @AllArgsConstructor
 public class CustomSetting

--- a/src/main/java/com/pluginpresets/CustomSettingsManager.java
+++ b/src/main/java/com/pluginpresets/CustomSettingsManager.java
@@ -27,19 +27,27 @@ package com.pluginpresets;
 import java.util.ArrayList;
 import java.util.List;
 import javax.inject.Inject;
-import lombok.Data;
+import javax.inject.Singleton;
 
-@Data
-public class CustomSettings
+/**
+ * Container storing all custom settings from all plugins across all presets
+ */
+@Singleton
+public class CustomSettingsManager
 {
-	private List<CustomSetting> settings;
+	private final List<CustomSetting> settings;
 
 	@Inject
-	public CustomSettings()
+	public CustomSettingsManager()
 	{
 		this.settings = new ArrayList<>();
 	}
 
+	/**
+	 * Finds custom settings for an individual plugin preset.
+	 * @param id the id of the preset to match against
+	 * @return all matching custom settings
+	 */
 	public List<CustomSetting> getCustomSettingsFor(long id)
 	{
 		ArrayList<CustomSetting> customSettingsList = new ArrayList<>();
@@ -55,6 +63,11 @@ public class CustomSettings
 		return customSettingsList;
 	}
 
+	/**
+	 * Finds custom settings for all presets matching a plugin config name.
+	 * @param configName the config name of the plugin
+	 * @return all matching custom settings
+	 */
 	public List<CustomSetting> getCustomConfigsFor(String configName)
 	{
 		ArrayList<CustomSetting> customSettingsList = new ArrayList<>();
@@ -70,6 +83,10 @@ public class CustomSettings
 		return customSettingsList;
 	}
 
+	/**
+	 * Finds and stores custom settings given all plugin presets
+	 * @param pluginPresets all the user's presets
+	 */
 	public void parseCustomSettings(List<PluginPreset> pluginPresets)
 	{
 		settings.clear();

--- a/src/main/java/com/pluginpresets/PluginConfig.java
+++ b/src/main/java/com/pluginpresets/PluginConfig.java
@@ -30,7 +30,7 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 
 /**
- * Class for a single RuneLite plugin.
+ * The config for an individual plugin within a preset. Contains various PluginSettings.
  *
  * @param name       Name of the plugin configuration
  * @param configName RuneLite config name

--- a/src/main/java/com/pluginpresets/PluginPreset.java
+++ b/src/main/java/com/pluginpresets/PluginPreset.java
@@ -32,7 +32,7 @@ import lombok.Setter;
 import net.runelite.client.config.Keybind;
 
 /**
- * Class depicting single PluginPreset file.
+ * A single preset which contains multiple PluginConfigs, each of which contains various PluginSettings.
  *
  * @param id            Time of creation used as id
  * @param name          Name of the preset

--- a/src/main/java/com/pluginpresets/PluginPresetsPlugin.java
+++ b/src/main/java/com/pluginpresets/PluginPresetsPlugin.java
@@ -97,7 +97,7 @@ public class PluginPresetsPlugin extends Plugin
 
 	@Getter
 	@Inject
-	private CustomSettings customSettings;
+	private CustomSettingsManager customSettingsManager;
 
 	@Inject
 	private ClientToolbar clientToolbar;
@@ -365,11 +365,11 @@ public class PluginPresetsPlugin extends Plugin
 		pluginPresets.addAll(presetStorage.loadPresets());
 		loadConfig(configManager.getConfiguration(CONFIG_GROUP, CONFIG_KEY));
 		pluginPresets.sort(Comparator.comparing(PluginPreset::getName)); // Keep presets in order
-		customSettings.parseCustomSettings(pluginPresets);
-		cacheKeybins();
+		customSettingsManager.parseCustomSettings(pluginPresets);
+		cacheKeybinds();
 	}
 
-	private void cacheKeybins()
+	private void cacheKeybinds()
 	{
 		keybinds.clear();
 		pluginPresets.forEach(preset ->

--- a/src/main/java/com/pluginpresets/PluginPresetsPresetEditor.java
+++ b/src/main/java/com/pluginpresets/PluginPresetsPresetEditor.java
@@ -30,6 +30,10 @@ import java.util.stream.Collectors;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
+/**
+ * Handles updating a preset: enabling/disabling plugin configs and their individual settings.
+ * Globally saves changes to the preset if needed.
+ */
 @Slf4j
 public class PluginPresetsPresetEditor
 {
@@ -46,6 +50,11 @@ public class PluginPresetsPresetEditor
 		this.currentConfigurations = currentConfigurations;
 	}
 
+	/**
+	 * Removes the given plugin config from the preset.
+	 * Switching to this preset will not affect any of the plugin's settings from this point on.
+	 * @param configuration the plugin to remove from this preset
+	 */
 	public void removeConfigurationFromEdited(PluginConfig configuration)
 	{
 		removeConfigurationFromEdited(configuration, false);
@@ -65,6 +74,11 @@ public class PluginPresetsPresetEditor
 		}
 	}
 
+	/**
+	 * Adds the given plugin config to the preset.
+	 * Switching to this preset changes some or all the plugin's settings to whatever the preset has saved.
+	 * @param configuration the plugin to add to this preset
+	 */
 	public void addConfigurationToEdited(PluginConfig configuration)
 	{
 		addConfigurationToEdited(configuration, false);
@@ -82,6 +96,12 @@ public class PluginPresetsPresetEditor
 		}
 	}
 
+	/**
+	 * Removes a setting from a config in this preset.
+	 * Switching to this preset will not affect this setting from this point on.
+	 * @param currentConfig the setting's parent config
+	 * @param setting the setting to remove from the preset
+	 */
 	public void removeSettingFromEdited(PluginConfig currentConfig, PluginSetting setting)
 	{
 		editedPreset.getPluginConfigs().forEach(configuration ->
@@ -102,6 +122,12 @@ public class PluginPresetsPresetEditor
 		updateEditedPreset();
 	}
 
+	/**
+	 * Adds a setting to a config in this preset.
+	 * Switching to this preset changes this setting to whatever the preset has saved.
+	 * @param currentConfig the setting's parent config
+	 * @param setting the setting to add to the preset
+	 */
 	public void addSettingToEdited(PluginConfig currentConfig, PluginSetting setting)
 	{
 		boolean noneMatch = editedPreset.getPluginConfigs().stream().noneMatch(c -> c.getName().equals(currentConfig.getName()));
@@ -125,6 +151,13 @@ public class PluginPresetsPresetEditor
 		updateEditedPreset();
 	}
 
+	/**
+	 * Adds a custom setting key to a config in this preset.
+	 * Switching to this preset changes this custom setting to whatever the preset has saved.
+	 * @param currentConfig the config that will house the custom setting (plugin config name may not always be
+	 *                      equal to the custom setting's config key)
+	 * @param customSetting the setting key to add, in the format configKey.settingKey
+	 */
 	public void addCustomSettingToEdited(PluginConfig currentConfig, String customSetting)
 	{
 		String configName;
@@ -169,12 +202,20 @@ public class PluginPresetsPresetEditor
 		String value = plugin.getPresetManager().getConfiguration(configName, key);
 		PluginSetting setting = new PluginSetting(PluginPresetsUtils.splitAndCapitalize(key), key, value, configName, config.getConfigName());
 
-		config.getSettings().add(setting);
-
-		updateEditedPreset();
-		plugin.refreshPresets(); // Must do refresh to reload custom configs
+		// don't add this setting if its key is already present
+		if (config.getSetting(setting) == null)
+		{
+			config.getSettings().add(setting);
+			updateEditedPreset();
+			plugin.refreshPresets(); // Must do refresh to reload custom configs
+		}
 	}
 
+	/**
+	 * Adds the given plugin config's on/off status to the preset.
+	 * Switching to this preset changes whether the plugin is enabled.
+	 * @param currentConfig the plugin to enable/disable in this preset
+	 */
 	public void addEnabledToEdited(PluginConfig currentConfig)
 	{
 		boolean noneMatch = editedPreset.getPluginConfigs().stream().noneMatch(c -> currentConfig.getName().equals(c.getName()));
@@ -197,6 +238,11 @@ public class PluginPresetsPresetEditor
 		updateEditedPreset();
 	}
 
+	/**
+	 * Removes the given plugin config's on/off status from the preset.
+	 * Switching to this preset will not change the plugin's on/off status.
+	 * @param currentConfig the plugin that will no longer be enabled/disabled by this preset
+	 */
 	public void removeEnabledFromEdited(PluginConfig currentConfig)
 	{
 		editedPreset.getPluginConfigs().forEach(configurations ->
@@ -214,6 +260,10 @@ public class PluginPresetsPresetEditor
 		updateEditedPreset();
 	}
 
+	/**
+	 * Adds the config for the given plugin in all the user's presets.
+	 * @param configuration the plugin config to add to all presets
+	 */
 	public void addConfigurationToPresets(PluginConfig configuration)
 	{
 		addConfigurationToEdited(configuration);
@@ -232,6 +282,10 @@ public class PluginPresetsPresetEditor
 		});
 	}
 
+	/**
+	 * Removes the config for the given plugin from all the user's presets.
+	 * @param configuration the plugin config to remove from all presets
+	 */
 	public void removeConfigurationFromPresets(PluginConfig configuration)
 	{
 		removeConfigurationFromEdited(configuration);
@@ -246,6 +300,11 @@ public class PluginPresetsPresetEditor
 		plugin.savePresets();
 	}
 
+	/**
+	 * Replaces an existing config in this preset with the provided (current) config.
+	 * @param presetConfig the preset config to replace
+	 * @param currentConfig the current config that will replace presetConfig
+	 */
 	public void updateConfigurations(PluginConfig presetConfig, PluginConfig currentConfig)
 	{
 		removeConfigurationFromEdited(presetConfig, true);
@@ -265,6 +324,9 @@ public class PluginPresetsPresetEditor
 		updateEditedPreset();
 	}
 
+	/**
+	 * Updates this preset, replacing all preset configs that have been modified with their current values.
+	 */
 	public void updateAllModified()
 	{
 		for (PluginConfig presetConfig : editedPreset.getPluginConfigs())
@@ -309,6 +371,10 @@ public class PluginPresetsPresetEditor
 		updateEditedPreset();
 	}
 
+	/**
+	 * Adds all provided configs to this preset.
+	 * @param pluginConfigs configs to add
+	 */
 	public void addAll(List<PluginConfig> pluginConfigs)
 	{
 		for (PluginConfig pluginConfig : pluginConfigs)
@@ -319,6 +385,10 @@ public class PluginPresetsPresetEditor
 		updateEditedPreset();
 	}
 
+	/**
+	 * Removes all provided configs from this preset.
+	 * @param pluginConfigs configs to remove
+	 */
 	public void removeAll(List<PluginConfig> pluginConfigs)
 	{
 		for (PluginConfig pluginConfig : pluginConfigs)
@@ -328,6 +398,9 @@ public class PluginPresetsPresetEditor
 		updateEditedPreset();
 	}
 
+	/**
+	 * Toggles cloud/local storage for this preset.
+	 */
 	public void toggleLocal()
 	{
 		editedPreset.setLocal(!editedPreset.getLocal());

--- a/src/main/java/com/pluginpresets/PluginPresetsPresetManager.java
+++ b/src/main/java/com/pluginpresets/PluginPresetsPresetManager.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
+import javax.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
@@ -39,7 +40,11 @@ import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.plugins.PluginInstantiationException;
 import net.runelite.client.plugins.PluginManager;
 
+/**
+ * Handles loading presets and creating new ones
+ */
 @Slf4j
+@Singleton
 public class PluginPresetsPresetManager
 {
 	private final PluginManager pluginManager;

--- a/src/main/java/com/pluginpresets/PluginSetting.java
+++ b/src/main/java/com/pluginpresets/PluginSetting.java
@@ -28,9 +28,9 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 
 /**
- * Class for storing single plugin setting
+ * The setting for a single item in a PluginConfig.
  *
- * @param name             Name of the setting
+ * @param name             Displayed name of the setting
  * @param key              Key used internally by configManager
  * @param value            Value of the setting
  * @param customConfigName Optional different config name that Plugin configs

--- a/src/main/java/com/pluginpresets/ui/ConfigPanel.java
+++ b/src/main/java/com/pluginpresets/ui/ConfigPanel.java
@@ -53,6 +53,9 @@ import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.util.ImageUtil;
 
+/**
+ * Panel for editing a single preset
+ */
 public class ConfigPanel extends JPanel
 {
 	private static final ImageIcon CHECKBOX_ICON;
@@ -133,6 +136,8 @@ public class ConfigPanel extends JPanel
 		JLabel title = new JLabel();
 		JLabel downArrow = new JLabel();
 		title.setText(currentConfig.getName());
+		JPopupMenu customSettingPopupMenu = getCustomSettingPopupMenu();
+		title.setComponentPopupMenu(customSettingPopupMenu);
 		// 0 width is to prevent the title causing the panel to grow in y direction on long plugin names
 		// 16 height is UPDATE_ICONs height
 		title.setPreferredSize(new Dimension(0, 26));
@@ -143,12 +148,7 @@ public class ConfigPanel extends JPanel
 			@Override
 			public void mousePressed(MouseEvent mouseEvent)
 			{
-				if (mouseEvent.getButton() == MouseEvent.BUTTON3) // Right click
-				{
-					JPopupMenu customSettingPopupMenu = getCustomSettingPopupMenu();
-					title.setComponentPopupMenu(customSettingPopupMenu);
-				}
-				else
+				if (mouseEvent.getButton() != MouseEvent.BUTTON3) // Right click
 				{
 					toggleSettings();
 				}
@@ -200,17 +200,14 @@ public class ConfigPanel extends JPanel
 		{
 			checkbox.setSelected(true);
 			checkbox.setToolTipText("Remove '" + currentConfig.getName() + "' configurations from the preset.");
+			JPopupMenu updateAllPopupMenu = getUpdateAllMenuPopup();
+			checkbox.setComponentPopupMenu(updateAllPopupMenu);
 			checkbox.addMouseListener(new MouseAdapter()
 			{
 				@Override
 				public void mousePressed(MouseEvent mouseEvent)
 				{
-					if (mouseEvent.getButton() == MouseEvent.BUTTON3) // Right click
-					{
-						JPopupMenu updateAllPopupMenu = getUpdateAllMenuPopup();
-						checkbox.setComponentPopupMenu(updateAllPopupMenu);
-					}
-					else
+					if (mouseEvent.getButton() != MouseEvent.BUTTON3) // Right click
 					{
 						presetEditor.removeConfigurationFromEdited(presetConfig);
 					}
@@ -303,17 +300,14 @@ public class ConfigPanel extends JPanel
 
 			checkbox.setSelected(false);
 			checkbox.setToolTipText("Add your current '" + currentConfig.getName() + "' configurations to the preset.");
+			JPopupMenu updateAllPopupMenu = getUpdateAllMenuPopup();
+			checkbox.setComponentPopupMenu(updateAllPopupMenu);
 			checkbox.addMouseListener(new MouseAdapter()
 			{
 				@Override
 				public void mousePressed(MouseEvent mouseEvent)
 				{
-					if (mouseEvent.getButton() == MouseEvent.BUTTON3) // Right click
-					{
-						JPopupMenu updateAllPopupMenu = getUpdateAllMenuPopup();
-						checkbox.setComponentPopupMenu(updateAllPopupMenu);
-					}
-					else
+					if (mouseEvent.getButton() != MouseEvent.BUTTON3) // Right click
 					{
 						presetEditor.addConfigurationToEdited(currentConfig);
 					}
@@ -540,7 +534,7 @@ public class ConfigPanel extends JPanel
 	private void promptCustomSettingInput()
 	{
 		String customPresetName = JOptionPane.showInputDialog(ConfigPanel.this,
-			"Format: configName.settingKey", "Add custom setting to " + currentConfig.getName(), JOptionPane.PLAIN_MESSAGE);
+			"Format: configName.settingKey", currentConfig.getName() + " custom setting", JOptionPane.PLAIN_MESSAGE);
 
 		if (customPresetName != null && customPresetName.length() > 0)
 		{

--- a/src/main/java/com/pluginpresets/ui/ConfigRow.java
+++ b/src/main/java/com/pluginpresets/ui/ConfigRow.java
@@ -45,6 +45,9 @@ import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.util.ImageUtil;
 
+/**
+ * Row for editing a single config of a plugin in the current preset
+ */
 public class ConfigRow extends JPanel
 {
 	private static final ImageIcon CHECKBOX_CHECKED_ICON;

--- a/src/main/java/com/pluginpresets/ui/PluginPresetsPluginPanel.java
+++ b/src/main/java/com/pluginpresets/ui/PluginPresetsPluginPanel.java
@@ -57,6 +57,7 @@ import javax.swing.ScrollPaneConstants;
 import javax.swing.border.EmptyBorder;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
+import lombok.extern.slf4j.Slf4j;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.PluginPanel;
 import net.runelite.client.ui.components.IconTextField;
@@ -64,6 +65,10 @@ import net.runelite.client.ui.components.PluginErrorPanel;
 import net.runelite.client.util.ImageUtil;
 import net.runelite.client.util.LinkBrowser;
 
+/**
+ * Main panel displaying all plugin presets
+ */
+@Slf4j
 public class PluginPresetsPluginPanel extends PluginPanel
 {
 	private static final ImageIcon NOTIFICATION_ICON;
@@ -220,17 +225,14 @@ public class PluginPresetsPluginPanel extends PluginPanel
 		});
 
 		addPreset.setToolTipText("Create new plugin preset");
+		JPopupMenu importPopupMenu = getImportMenuPopup();
+		addPreset.setComponentPopupMenu(importPopupMenu);
 		addPreset.addMouseListener(new MouseAdapter()
 		{
 			@Override
 			public void mousePressed(MouseEvent mouseEvent)
 			{
-				if (mouseEvent.getButton() == MouseEvent.BUTTON3) // Right click
-				{
-					JPopupMenu importPopupMenu = getImportMenuPopup();
-					addPreset.setComponentPopupMenu(importPopupMenu);
-				}
-				else
+				if (mouseEvent.getButton() != MouseEvent.BUTTON3) // Right click
 				{
 					promptPresetCreation(true);
 				}
@@ -622,7 +624,7 @@ public class PluginPresetsPluginPanel extends PluginPanel
 
 	private void filterCustomConfigs(List<PluginConfig> configurations)
 	{
-		List<CustomSetting> editedPresetCustomSettings = plugin.getCustomSettings().getCustomSettingsFor(editedPreset.getId());
+		List<CustomSetting> editedPresetCustomSettings = plugin.getCustomSettingsManager().getCustomSettingsFor(editedPreset.getId());
 		List<String> customSettingKeys = editedPresetCustomSettings.stream().map(customSetting -> customSetting.getSetting().getKey()).collect(Collectors.toList());
 		configurations.forEach(c -> c.getSettings().removeIf(setting -> setting.getCustomConfigName() != null && !customSettingKeys.contains(setting.getKey())));
 	}

--- a/src/main/java/com/pluginpresets/ui/PresetPanel.java
+++ b/src/main/java/com/pluginpresets/ui/PresetPanel.java
@@ -55,6 +55,9 @@ import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.components.FlatTextField;
 import net.runelite.client.util.ImageUtil;
 
+/**
+ * Row representing a single preset in the list of presets
+ */
 class PresetPanel extends JPanel
 {
 	private static final Border NAME_BOTTOM_BORDER = new CompoundBorder(
@@ -276,18 +279,8 @@ class PresetPanel extends JPanel
 		loadLabel.setBorder(new EmptyBorder(0, 5, 0, 5));
 
 		Boolean loadOnFocus = preset.getLoadOnFocus();
-		loadLabel.addMouseListener(new MouseAdapter()
-		{
-			@Override
-			public void mousePressed(MouseEvent mouseEvent)
-			{
-				if (mouseEvent.getButton() == MouseEvent.BUTTON3) // Right click
-				{
-					JPopupMenu focusMenuPopup = getFocusMenuPopup(loadOnFocus);
-					loadLabel.setComponentPopupMenu(focusMenuPopup);
-				}
-			}
-		});
+		JPopupMenu focusMenuPopup = getFocusMenuPopup(loadOnFocus);
+		loadLabel.setComponentPopupMenu(focusMenuPopup);
 
 		JLabel notice = new JLabel();
 


### PR DESCRIPTION
Closes #39 
Summary of changes:
* Annotated some classes as singletons so that the different areas of code that access those classes all talk to the same instance. This was preventing the custom settings from being "synced" properly between the preset's stored values and the panel's ui. `CustomSettings` really seems like it should be a manager class, so I changed the class name as well.
* Modified logic of duplicate custom settings: previously, the custom setting parser would ignore any additional settings in the same config. In my case, I had several `region_###` keys under one config, so now this checks for duplicates by both the config and setting name. 
* When adding a custom setting key, there is no check to ensure that the key hasn't already been added, so I added one in.
* Various right click menus were previously only added upon right click. The menus are now added so that the first time they're right-clicked, they open the popup menu.
* Added some documentation to various classes and functions. This was mostly to prevent my own confusion since I get mixed up on presets, configs, and settings myself. Apologies if these docs seem obvious or are inaccurate.
* Updates to the readme: some typo fixes and grammar adjustments, as well as some bits of additional info.