### PR TITLE
Changing to presets which contain custom keys no longer causes infinite plugin toggle loop

### DIFF
--- a/src/main/java/com/pluginpresets/PluginPresetsPlugin.java
+++ b/src/main/java/com/pluginpresets/PluginPresetsPlugin.java
@@ -343,11 +343,12 @@ public class PluginPresetsPlugin extends Plugin
 	public void loadPreset(final PluginPreset preset)
 	{
 		loadingPreset = true;
-		presetManager.loadPreset(preset);
-		loadingPreset = false;
+		presetManager.loadPreset(preset, () -> {
+			loadingPreset = false;
 
-		updateCurrentConfigurations();
-		rebuildPluginUi();
+			updateCurrentConfigurations();
+			rebuildPluginUi();
+		});
 	}
 
 	public void deletePreset(final PluginPreset preset)


### PR DESCRIPTION
Fixes #43 

The restarting process for plugins that contain custom settings has been moved to the last stage of loading the preset, and the restart is only performed if it's needed, since the plugin could be toggled according to the preset already.

I noticed the original problem when toggling between presets that contain custom keys for ground markers, and after some testing with this fix in place, I haven't been able to reproduce the bug.

I think it's a pretty ugly solution (completion blocks suck), but it looks like the issue stems from things outside of the plugin's control.