### PR TITLE
fix: improve behaviour when enabling auto update

### DIFF
--- a/src/main/java/com/pluginpresets/PluginPresetsPlugin.java
+++ b/src/main/java/com/pluginpresets/PluginPresetsPlugin.java
@@ -463,14 +463,23 @@ public class PluginPresetsPlugin extends Plugin
 				}
 			}
 			setupAutoUpdater();
+			rebuildPluginUi();
 		}
 
+	}
+
+	public void AddAutoUpdateFrom(PluginPreset preset)
+	{
+		preset.setAutoUpdated(true);
+		savePresets();
+		rebuildPluginUi();
 	}
 
 	public void removeAutoUpdateFrom(PluginPreset preset)
 	{
 		preset.setAutoUpdated(null);
 		savePresets();
+		rebuildPluginUi();
 	}
 
 	public void importPresetFromClipboard()

--- a/src/main/java/com/pluginpresets/PluginPresetsPlugin.java
+++ b/src/main/java/com/pluginpresets/PluginPresetsPlugin.java
@@ -468,7 +468,7 @@ public class PluginPresetsPlugin extends Plugin
 
 	}
 
-	public void AddAutoUpdateFrom(PluginPreset preset)
+	public void addAutoUpdateFrom(PluginPreset preset)
 	{
 		preset.setAutoUpdated(true);
 		savePresets();

--- a/src/main/java/com/pluginpresets/ui/PluginPresetsPluginPanel.java
+++ b/src/main/java/com/pluginpresets/ui/PluginPresetsPluginPanel.java
@@ -617,8 +617,16 @@ public class PluginPresetsPluginPanel extends PluginPanel
 		String text = "Automatically run update all on this preset";
 		if (thisAutoUpdated)
 		{
-			autoUpdateLabel.setVisible(true);
-			updateAll.setVisible(false);
+			if (thisHasAutoUpdater)
+			{
+				updateAll.setVisible(false);
+				autoUpdateLabel.setVisible(true);
+			}
+			else
+			{
+				updateAll.setVisible(modified);
+				autoUpdateLabel.setVisible(false);
+			}
 			autoUpdate.setIcon(Icons.ORANGE_REFRESH_ICON);
 			text = "Turn auto updating off from this preset";
 		}
@@ -650,7 +658,7 @@ public class PluginPresetsPluginPanel extends PluginPanel
 				{
 					if (modified)
 					{
-						plugin.AddAutoUpdateFrom(plugin.getPresetEditor().getEditedPreset());
+						plugin.addAutoUpdateFrom(plugin.getPresetEditor().getEditedPreset());
 					}
 					else
 					{

--- a/src/main/java/com/pluginpresets/ui/PluginPresetsPluginPanel.java
+++ b/src/main/java/com/pluginpresets/ui/PluginPresetsPluginPanel.java
@@ -265,6 +265,10 @@ public class PluginPresetsPluginPanel extends PluginPanel
 			public void mousePressed(MouseEvent mouseEvent)
 			{
 				plugin.getPresetEditor().updateAllModified();
+				if (plugin.getAutoUpdater() == null && editedPreset.getAutoUpdated() != null)
+				{
+					plugin.setAutoUpdatedPreset(plugin.getPresetEditor().getEditedPreset().getId());
+				}
 			}
 
 			@Override

--- a/src/main/java/com/pluginpresets/ui/PluginPresetsPluginPanel.java
+++ b/src/main/java/com/pluginpresets/ui/PluginPresetsPluginPanel.java
@@ -611,26 +611,16 @@ public class PluginPresetsPluginPanel extends PluginPanel
 	private void setUpdateAllVisibility(boolean modified)
 	{
 		boolean hasAutoUpdater = plugin.getAutoUpdater() != null;
-		boolean thisAutoUpdated = hasAutoUpdater && plugin.getAutoUpdater().getEditedPreset().getId() == editedPreset.getId();
+		boolean thisHasAutoUpdater = hasAutoUpdater && plugin.getAutoUpdater().getEditedPreset().getId() == editedPreset.getId();
+		boolean thisAutoUpdated = editedPreset.getAutoUpdated() != null;
 
 		String text = "Automatically run update all on this preset";
-		if (hasAutoUpdater)
+		if (thisAutoUpdated)
 		{
-			if (thisAutoUpdated)
-			{
-				autoUpdateLabel.setVisible(true);
-				updateAll.setVisible(false);
-				autoUpdate.setIcon(Icons.ORANGE_REFRESH_ICON);
-				text = "Turn auto updating off from this preset";
-			}
-			else
-			{
-				updateAll.setVisible(modified);
-				autoUpdateLabel.setVisible(false);
-				autoUpdate.setIcon(Icons.REFRESH_INACTIVE_ICON);
-				String name = plugin.getAutoUpdater().getEditedPreset().getName();
-				text = name + " is being auto updated. Click to update this preset instead.";
-			}
+			autoUpdateLabel.setVisible(true);
+			updateAll.setVisible(false);
+			autoUpdate.setIcon(Icons.ORANGE_REFRESH_ICON);
+			text = "Turn auto updating off from this preset";
 		}
 		else
 		{
@@ -651,12 +641,21 @@ public class PluginPresetsPluginPanel extends PluginPanel
 			{
 				if (thisAutoUpdated)
 				{
-					plugin.setAutoUpdatedPreset(null);
+					if (thisHasAutoUpdater) {
+						plugin.setAutoUpdatedPreset(null);
+					}
 					plugin.removeAutoUpdateFrom(plugin.getPresetEditor().getEditedPreset());
 				}
 				else
 				{
-					plugin.setAutoUpdatedPreset(plugin.getPresetEditor().getEditedPreset().getId());
+					if (modified)
+					{
+						plugin.AddAutoUpdateFrom(plugin.getPresetEditor().getEditedPreset());
+					}
+					else
+					{
+						plugin.setAutoUpdatedPreset(plugin.getPresetEditor().getEditedPreset().getId());
+					}
 				}
 			}
 


### PR DESCRIPTION
This PR changes the behaviour when enabling auto update on a given profile to not automatically overwrite everything. Automatic updates will only be enabled if the preset is matching, otherwise it will put it into the idle state where it will be enabled when the profile is loaded.

This is a draft due to there being a bug I can't seem to fix where if you click the auto update icon in the preset config menu twice in a row there is unexpected behaviour. If you only click it once and then exit out of that menu to the main profile list and re-enter, everything works as expected.