### PR TITLE
Fix presets deleted with multiple clients

### DIFF
--- a/src/main/java/com/pluginpresets/ui/PluginPresetsPluginPanel.java
+++ b/src/main/java/com/pluginpresets/ui/PluginPresetsPluginPanel.java
@@ -77,7 +77,6 @@ public class PluginPresetsPluginPanel extends PluginPanel
 	private final JLabel pauseLabel = new JLabel();
 	private final JLabel addPreset = new JLabel(Icons.ADD_ICON);
 	private final JLabel stopEdit = new JLabel(Icons.ARROW_LEFT_ICON);
-	private final JLabel refreshPlugins = new JLabel(Icons.REFRESH_ICON);
 	private final JLabel ellipsisMenu = new JLabel(Icons.ELLIPSIS);
 	private final JLabel syncLabel = new JLabel();
 	private final JLabel updateAll = new JLabel(Icons.REFRESH_ICON);
@@ -163,31 +162,6 @@ public class PluginPresetsPluginPanel extends PluginPanel
 			}
 		});
 
-		refreshPlugins.setToolTipText("Refresh presets");
-		refreshPlugins.addMouseListener(new MouseAdapter()
-		{
-			@Override
-			public void mousePressed(MouseEvent mouseEvent)
-			{
-				if (mouseEvent.getButton() == MouseEvent.BUTTON1)
-				{
-					plugin.refreshPresets();
-				}
-			}
-
-			@Override
-			public void mouseEntered(MouseEvent mouseEvent)
-			{
-				refreshPlugins.setIcon(Icons.REFRESH_HOVER_ICON);
-			}
-
-			@Override
-			public void mouseExited(MouseEvent mouseEvent)
-			{
-				refreshPlugins.setIcon(Icons.REFRESH_ICON);
-			}
-		});
-
 		addPreset.setToolTipText("Create new plugin preset");
 		JPopupMenu importPopupMenu = getImportMenuPopup();
 		addPreset.setComponentPopupMenu(importPopupMenu);
@@ -218,7 +192,6 @@ public class PluginPresetsPluginPanel extends PluginPanel
 		presetActions.add(errorNotification);
 		presetActions.add(pauseLabel);
 		presetActions.add(helpButton);
-		presetActions.add(refreshPlugins);
 		presetActions.add(addPreset);
 
 		titlePanel.add(title, BorderLayout.WEST);


### PR DESCRIPTION
Fix "All presets deleted when using multiple clients #80"

Add synchronization to handle multiple clients open at the same time.
Remove refresh button.

This should also resolve the presets "flashing" defects.